### PR TITLE
Add dependecies to `require` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Added Relay configuration file
+- Enabled msgpack for PhpRedis
+- Fixed `require` blocks for Relay and PhpRedis
+
 ## [1.2.0] - 2021-05-26
 - Added [Relay](https://relaycache.com) v0.1.0
 - Added [MessagePack](https://github.com/msgpack/msgpack-php) v2.1.2

--- a/extensions/no-debug-non-zts-20131226/redis
+++ b/extensions/no-debug-non-zts-20131226/redis
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 dep_name=$(basename $BASH_SOURCE)
+series=$(php-config --version | cut -d. -f1,2)
 
 export PKG_CONFIG_PATH=/app/.heroku/php/lib/pkgconfig
 

--- a/extensions/no-debug-non-zts-20131226/redis
+++ b/extensions/no-debug-non-zts-20131226/redis
@@ -2,6 +2,9 @@
 
 dep_name=$(basename $BASH_SOURCE)
 
+echo $PATH
+find /app -name 'php-config'
+
 series=$($OUT_PREFIX/bin/php-config --version | cut -d. -f1,2)
 
 export PKG_CONFIG_PATH=/app/.heroku/php/lib/pkgconfig

--- a/extensions/no-debug-non-zts-20131226/redis
+++ b/extensions/no-debug-non-zts-20131226/redis
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 dep_name=$(basename $BASH_SOURCE)
-series=$(php-config --version | cut -d. -f1,2)
+
+series=$($OUT_PREFIX/bin/php-config --version | cut -d. -f1,2)
 
 export PKG_CONFIG_PATH=/app/.heroku/php/lib/pkgconfig
 

--- a/extensions/no-debug-non-zts-20131226/redis
+++ b/extensions/no-debug-non-zts-20131226/redis
@@ -4,7 +4,7 @@ dep_name=$(basename $BASH_SOURCE)
 
 export PKG_CONFIG_PATH=/app/.heroku/php/lib/pkgconfig
 
-CONFIGURE_EXTRA="--enable-redis-igbinary --enable-redis-lzf --enable-redis-zstd --enable-redis-lz4 --with-liblz4=/usr/local"
+CONFIGURE_EXTRA="--enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --enable-redis-zstd --enable-redis-lz4 --with-liblz4=/usr/local"
 
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\",\"heroku-sys/liblzf\":\"*\",\"heroku-sys/lz4\":\"*\",\"heroku-sys/zstd\":\"*\",\"heroku-sys/ext-json\":\"*\",\"heroku-sys/ext-igbinary\":\"*\",\"heroku-sys/ext-msgpack\":\"*\"}"}"
 

--- a/extensions/no-debug-non-zts-20131226/redis
+++ b/extensions/no-debug-non-zts-20131226/redis
@@ -2,10 +2,7 @@
 
 dep_name=$(basename $BASH_SOURCE)
 
-echo $PATH
-find /app -name 'php-config'
-
-series=$($OUT_PREFIX/bin/php-config --version | cut -d. -f1,2)
+series=$(/app/.heroku/php/bin/php-config --version | cut -d. -f1,2)
 
 export PKG_CONFIG_PATH=/app/.heroku/php/lib/pkgconfig
 

--- a/extensions/no-debug-non-zts-20131226/redis
+++ b/extensions/no-debug-non-zts-20131226/redis
@@ -6,4 +6,6 @@ export PKG_CONFIG_PATH=/app/.heroku/php/lib/pkgconfig
 
 CONFIGURE_EXTRA="--enable-redis-igbinary --enable-redis-lzf --enable-redis-zstd --enable-redis-lz4 --with-liblz4=/usr/local"
 
+MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\",\"heroku-sys/liblzf\":\"*\",\"heroku-sys/lz4\":\"*\",\"heroku-sys/zstd\":\"*\",\"heroku-sys/ext-json\":\"*\",\"heroku-sys/ext-igbinary\":\"*\",\"heroku-sys/ext-msgpack\":\"*\"}"}"
+
 source $(dirname $BASH_SOURCE)/../../vendor/heroku/heroku-buildpack-php/support/build/extensions/pecl

--- a/extensions/no-debug-non-zts-20131226/relay
+++ b/extensions/no-debug-non-zts-20131226/relay
@@ -27,17 +27,22 @@ curl -L ${dep_url} | tar xz
 
 pushd ${dep_dirname}
 rm -rf ${OUT_PREFIX}/*
+
 uuid=$(cat /proc/sys/kernel/random/uuid)
 sed -i "s/31415926-5358-9793-2384-626433832795/${uuid}/" relay-static.so
+
 mkdir -p ${php_ext_dir}
-mv relay-static.so ${php_ext_dir}/relay.so
+cp relay-static.so ${php_ext_dir}/relay.so
+
+mkdir -p ${OUT_PREFIX}/etc/php/conf.d
+cp relay.ini ${OUT_PREFIX}/etc/php/conf.d/relay.ini-dist
 popd
 
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\",\"heroku-sys/liblzf\":\"*\",\"heroku-sys/lz4\":\"*\",\"heroku-sys/zstd\":\"*\",\"heroku-sys/ext-json\":\"*\",\"heroku-sys/ext-igbinary\":\"*\",\"heroku-sys/ext-msgpack\":\"*\"}"}"
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{}"}"
 MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
-MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{}"}"
+MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/relay.ini-dist\"}"}"
 
 python $(dirname $BASH_SOURCE)/../../vendor/heroku/heroku-buildpack-php/support/build/_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 

--- a/extensions/no-debug-non-zts-20131226/relay
+++ b/extensions/no-debug-non-zts-20131226/relay
@@ -33,7 +33,7 @@ mkdir -p ${php_ext_dir}
 mv relay-static.so ${php_ext_dir}/relay.so
 popd
 
-MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\"}"}"
+MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\",\"heroku-sys/liblzf\":\"*\",\"heroku-sys/lz4\":\"*\",\"heroku-sys/zstd\":\"*\",\"heroku-sys/ext-json\":\"*\",\"heroku-sys/ext-igbinary\":\"*\",\"heroku-sys/ext-msgpack\":\"*\"}"}"
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{}"}"
 MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"

--- a/extensions/no-debug-non-zts-20180731/redis-5.3.4
+++ b/extensions/no-debug-non-zts-20180731/redis-5.3.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php
-# Build Deps: php-7.3.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20180731/igbinary-*
+# Build Deps: php-7.3.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20180731/igbinary-*, extensions/no-debug-non-zts-20180731/msgpack-*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/redis

--- a/extensions/no-debug-non-zts-20190902/redis-5.3.4
+++ b/extensions/no-debug-non-zts-20190902/redis-5.3.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php
-# Build Deps: php-7.4.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20190902/igbinary-*
+# Build Deps: php-7.4.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20190902/igbinary-*, extensions/no-debug-non-zts-20190902/msgpack-*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/redis

--- a/extensions/no-debug-non-zts-20200930/redis-5.3.4
+++ b/extensions/no-debug-non-zts-20200930/redis-5.3.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php
-# Build Deps: php-8.0.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20200930/igbinary-*
+# Build Deps: php-8.0.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20200930/igbinary-*, extensions/no-debug-non-zts-20200930/msgpack-*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/redis


### PR DESCRIPTION
Ensure `require` block still contains all base dependencies.

```
require": {
    "heroku-sys/heroku": "^18.0.0",
    "heroku-sys/php": "7.3.*",
    "heroku/installer-plugin": "^1.2.0"
},
```