### PR TITLE
Enable PostgreSQL coroutine client which was merged to core in 5.0.0

### DIFF
--- a/extensions/no-debug-non-zts-20210902/swoole-5.0.0
+++ b/extensions/no-debug-non-zts-20210902/swoole-5.0.0
@@ -2,6 +2,6 @@
 # Build Path: /app/.heroku/php
 # Build Deps: php-8.1.*
 
-CONFIGURE_EXTRA="--enable-swoole-curl --enable-sockets --enable-mysqlnd --enable-openssl"
+CONFIGURE_EXTRA="--enable-swoole-curl --enable-sockets --enable-mysqlnd --enable-openssl --enable-swoole-pgsql"
 
 source $(dirname $0)/../no-debug-non-zts-20131226/swoole


### PR DESCRIPTION
Can we please add this configure option to have PostgreSQL support in swoole 5

"Migrate pgsql coroutine client to core"
    \- [swoole-src Release v5.0.0 notes](https://github.com/swoole/swoole-src/releases/tag/v5.0.0)

"Add compile options when compiling Swoole: `./configure --enable-swoole-pgsql`"
    \- [Swoole.com Coroutine\PostgreSQL documentation](https://wiki.swoole.com/#/coroutine_client/postgresql?id=%e7%bc%96%e8%af%91%e5%ae%89%e8%a3%85)

The docs also describe dependency on `libpq`, however I see `libpq-dev` and `libpq5` are listed on [Heroku stack packages docs](https://devcenter.heroku.com/articles/stack-packages), is that good enough? We don't have to build it ourselves like lz4/liblzf/etc.?