### PR TITLE
Drop heroku-18 stack support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         stack:
-          - heroku-18
           - heroku-20
           - heroku-22
         series:

--- a/.github/workflows/mkrepo.yml
+++ b/.github/workflows/mkrepo.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        stack: ['heroku-18', 'heroku-20', 'heroku-22']
+        stack: ['heroku-20', 'heroku-22']
 
     env:
       S3_BUCKET: heroku-php-extensions

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         stack:
-          - heroku-18
           - heroku-20
           - heroku-22
         series:
@@ -28,6 +27,7 @@ jobs:
           - 20190902 # PHP 7.4
           - 20200930 # PHP 8.0
           - 20210902 # PHP 8.1
+          - 20220829 # PHP 8.2
 
     steps:
       - name: Checkout
@@ -143,7 +143,7 @@ jobs:
 
     strategy:
       matrix:
-        stack: ['heroku-18', 'heroku-20', 'heroku-22']
+        stack: ['heroku-20', 'heroku-22']
 
     steps:
       - name: Checkout

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        stack: ['heroku-18', 'heroku-20', 'heroku-22']
+        stack: ['heroku-20', 'heroku-22']
 
     env:
       S3_BUCKET: heroku-php-extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Dropped `heroku-18` support
+
 ## [1.2.6] - 2022-10-11
 - Added support for `heroku-22` stack
 - Added [OpenSwoole](https://github.com/openswoole/swoole-src) v4.12.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pre-built PHP extensions for Heroku that are not included or fully supported by 
 - [MessagePack](https://pecl.php.net/package/msgpack)
 - [igbinary](https://pecl.php.net/package/igbinary)
 
-The supported PHP versions are `7.3`, `7.4`, `8.0` and `8.1` on the `heroku-18`, `heroku-20`, and `heroku-22` stacks.
+The supported PHP versions are `7.3`, `7.4`, `8.0` and `8.1` on the `heroku-20` and `heroku-22` stacks.
 
 Checkout the [demo app](https://php-extensions.herokuapp.com), or [browse the S3 bucket](https://s3.us-east-1.amazonaws.com/heroku-php-extensions/index.html).
 
@@ -24,9 +24,6 @@ heroku config:set HEROKU_PHP_PLATFORM_REPOSITORIES="https://relay.so/heroku/"
 If you prefer using the AWS S3 repositories, add the corresponding repository to your Heroku app:
 
 ```bash
-# heroku-18
-heroku config:set HEROKU_PHP_PLATFORM_REPOSITORIES="https://heroku-php-extensions.s3.amazonaws.com/dist-heroku-18-stable/"
-
 # heroku-20
 heroku config:set HEROKU_PHP_PLATFORM_REPOSITORIES="https://heroku-php-extensions.s3.amazonaws.com/dist-heroku-20-stable/"
 


### PR DESCRIPTION
Drop support for the EoL heroku-18 stack, also add PHP 8.2 to the PR workflow so #26 can be tested