### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           - 20200930 # PHP 8.0
           - 20210902 # PHP 8.1
           - 20220829 # PHP 8.2
+          - 20230831 # PHP 8.3
 
     steps:
       - name: Checkout

--- a/extensions/no-debug-non-zts-20230831/igbinary-3.2.15
+++ b/extensions/no-debug-non-zts-20230831/igbinary-3.2.15
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.3.*
+
+source $(dirname $0)/../no-debug-non-zts-20131226/igbinary

--- a/extensions/no-debug-non-zts-20230831/msgpack-2.2.0
+++ b/extensions/no-debug-non-zts-20230831/msgpack-2.2.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.3.*
+
+source $(dirname $0)/../no-debug-non-zts-20131226/msgpack

--- a/extensions/no-debug-non-zts-20230831/openswoole-4.12.1
+++ b/extensions/no-debug-non-zts-20230831/openswoole-4.12.1
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.3.*
+
+source $(dirname $0)/../no-debug-non-zts-20131226/openswoole

--- a/extensions/no-debug-non-zts-20230831/redis-6.0.2
+++ b/extensions/no-debug-non-zts-20230831/redis-6.0.2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.3.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20220829/igbinary-*, extensions/no-debug-non-zts-20220829/msgpack-*
+
+source $(dirname $0)/../no-debug-non-zts-20131226/redis

--- a/extensions/no-debug-non-zts-20230831/relay-0.6.8
+++ b/extensions/no-debug-non-zts-20230831/relay-0.6.8
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.3.*, libraries/liblzf-*, libraries/lz4-*, libraries/zstd-*, extensions/no-debug-non-zts-20220829/igbinary-*, extensions/no-debug-non-zts-20220829/msgpack-*
+
+source $(dirname $0)/../no-debug-non-zts-20131226/relay

--- a/extensions/no-debug-non-zts-20230831/swoole-4.8.13
+++ b/extensions/no-debug-non-zts-20230831/swoole-4.8.13
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.3.*
+
+source $(dirname $0)/../no-debug-non-zts-20131226/swoole


### PR DESCRIPTION
Got the number `20230831` from here: 
https://github.com/php/php-src/blob/d26068059e83fe40de3430a512471d194119bee0/main/php.h#L25C25-L25C33

And copied the folder from the previous (`no-debug-non-zts-20220829` = PHP 8.2) version.

Let me know if that's the way to do it   👀

Appreciating your work btw, it's priceless when using Heroku.