### PR TITLE
Heroku 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       S3_BUCKET: ${{ secrets.S3_BUCKET || 'heroku-php-extensions' }}
       S3_PREFIX: ${{ inputs.S3_PREFIX || matrix.stack.prefix }}
+      S3_REGION: ${{ secrets.S3_REGION || 'us-east-1' }}
       BUILDPACK: ./vendor/heroku/heroku-buildpack-php
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -30,11 +31,6 @@ jobs:
       fail-fast: false
       matrix:
         stack:
-          - name: "heroku-22"
-            arch: "amd64"
-            prefix: "dist-heroku-22-develop/"
-            upstream: "dist-heroku-22-stable/"
-            os: "ubuntu-latest"
           - name: "heroku-24"
             arch: "amd64"
             prefix: "dist-heroku-24-amd64-develop/"
@@ -45,31 +41,41 @@ jobs:
             prefix: "dist-heroku-24-arm64-develop/"
             upstream: "dist-heroku-24-arm64-stable/"
             os: "ubuntu-24.04-arm"
+          - name: "heroku-26"
+            arch: "amd64"
+            prefix: "dist-heroku-26-amd64-develop/"
+            upstream: "dist-heroku-26-amd64-stable/"
+            os: "ubuntu-latest"
+          - name: "heroku-26"
+            arch: "arm64"
+            prefix: "dist-heroku-26-arm64-develop/"
+            upstream: "dist-heroku-26-arm64-stable/"
+            os: "ubuntu-24.04-arm"
         series:
-          - { version: 20210902, php: "8.1", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["5.3.7", "6.3.0"], relay: ["0.21.0"], swoole: ["4.8.13", "5.1.8", "6.1.7"], openswoole: ["4.12.1", "22.1.2"] }
-          - { version: 20220829, php: "8.2", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["5.3.7", "6.3.0"], relay: ["0.21.0"], swoole: ["4.8.13", "5.1.8", "6.1.7"], openswoole: ["22.1.2", "25.2.0", "26.2.0"] }
-          - { version: 20230831, php: "8.3", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["5.3.7", "6.3.0"], relay: ["0.21.0"], swoole: ["5.1.8", "6.1.7"], openswoole: ["22.1.2", "25.2.0", "26.2.0"] }
-          - { version: 20240924, php: "8.4", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["6.3.0"], relay: ["0.21.0"], swoole: ["6.1.7"], openswoole: ["25.2.0", "26.2.0"] }
-          - { version: 20250925, php: "8.5", liblzf: "3.6", lz4: "1.10.0", zstd: "1.5.7", igbinary: "3.2.17RC1", msgpack: "2.2.0", redis: ["6.3.0"], relay: ["0.21.0"], swoole: ["6.2.0RC1"], openswoole: ["26.2.0"] }
+          - { php: "8.1", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["5.3.7", "6.3.0"], relay: ["0.21.0"], swoole: ["4.8.13", "5.1.8", "6.1.7"], openswoole: ["4.12.1", "22.1.2"] }
+          - { php: "8.2", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["5.3.7", "6.3.0"], relay: ["0.21.0"], swoole: ["4.8.13", "5.1.8", "6.1.7"], openswoole: ["22.1.2", "25.2.0", "26.2.0"] }
+          - { php: "8.3", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["5.3.7", "6.3.0"], relay: ["0.21.0"], swoole: ["5.1.8", "6.1.7"], openswoole: ["22.1.2", "25.2.0", "26.2.0"] }
+          - { php: "8.4", liblzf: "3.6", lz4: "1.9.3", zstd: "1.4.9", igbinary: "3.2.15", msgpack: "2.2.0", redis: ["6.3.0"], relay: ["0.21.0"], swoole: ["6.1.7"], openswoole: ["25.2.0", "26.2.0"] }
+          - { php: "8.5", liblzf: "3.6", lz4: "1.10.0", zstd: "1.5.7", igbinary: "3.2.17RC1", msgpack: "2.2.0", redis: ["6.3.0"], relay: ["0.21.0"], swoole: ["6.2.1"], openswoole: ["26.2.0"] }
         exclude:
           # heroku-24 no longer supports php-8.1
           - stack:
               name: "heroku-24"
             series:
-              version: 20210902
-        include:
-          # heroku-24 cannot compile openswoole 4.12.1 anymore, include for heroku-22 only
+              php: "8.1"
+          # heroku-26 no longer supports php-8.1, 8.2, 8.3
           - stack:
-              name: "heroku-22"
-              arch: "amd64"
-              prefix: "dist-heroku-22-develop/"
-              upstream: "dist-heroku-22-stable/"
-              os: "ubuntu-latest"
+              name: "heroku-26"
             series:
-              version: 20220829
+              php: "8.1"
+          - stack:
+              name: "heroku-26"
+            series:  
               php: "8.2"
-              openswoole:
-                - "4.12.1"
+          - stack:
+              name: "heroku-26"
+            series:
+              php: "8.3"
 
     steps:
       - name: Checkout
@@ -98,7 +104,7 @@ jobs:
             for (const { tag_name, prerelease, draft } of data) {
               const m = !prerelease && !draft && tag_name.match(re);
               if (!m) continue;
-              const res = await fetch(`https://lang-php.s3.amazonaws.com/${prefix}php-${m[1]}.tar.gz`, { method: 'HEAD' });
+              const res = await fetch(`https://heroku-buildpack-php.s3.amazonaws.com/${prefix}php-${m[1]}.tar.gz`, { method: 'HEAD' });
               if (res.ok) { core.exportVariable('PHP_VERSION', m[1]); break; }
             }
 
@@ -112,35 +118,35 @@ jobs:
         run: ./scripts/build-lib.sh ${{ matrix.stack.name }} zstd "${{ matrix.series.zstd }}" true
 
       - name: Build igbinary extension
-        run: ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} ${{ matrix.series.version }} igbinary "${{ matrix.series.igbinary }}" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
+        run: ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} igbinary "${{ matrix.series.igbinary }}" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
 
       - name: Build msgpack extension
-        run: ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} ${{ matrix.series.version }} msgpack "${{ matrix.series.msgpack }}" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
+        run: ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} msgpack "${{ matrix.series.msgpack }}" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
 
       - name: Build redis extensions
         run: |
           set -e
           for VERSION in ${{ join(matrix.series.redis, ' ') }}; do
-            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} ${{ matrix.series.version }} redis "$VERSION" "php-${{ env.PHP_VERSION }},libraries/liblzf-*,libraries/lz4-*,libraries/zstd-*,extensions/no-debug-non-zts-${{ matrix.series.version }}/igbinary-*,extensions/no-debug-non-zts-${{ matrix.series.version }}/msgpack-*" ${{ matrix.stack.upstream }} true
+            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} redis "$VERSION" "php-${{ env.PHP_VERSION }},liblzf-*,lz4-*,zstd-*,ext-igbinary-*_php-${{ matrix.series.php }},ext-msgpack-*_php-${{ matrix.series.php }}" ${{ matrix.stack.upstream }} true
           done
 
       - name: Build relay extension
         run: |
           set -e
           for VERSION in ${{ join(matrix.series.relay, ' ') }}; do
-            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} ${{ matrix.series.version }} relay "$VERSION" "php-${{ env.PHP_VERSION }},libraries/liblzf-*,libraries/lz4-*,libraries/zstd-*,extensions/no-debug-non-zts-${{ matrix.series.version }}/igbinary-*,extensions/no-debug-non-zts-${{ matrix.series.version }}/msgpack-*" ${{ matrix.stack.upstream }} true
+            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} relay "$VERSION" "php-${{ env.PHP_VERSION }},liblzf-*,lz4-*,zstd-*,ext-igbinary-*_php-${{ matrix.series.php }},ext-msgpack-*_php-${{ matrix.series.php }}" ${{ matrix.stack.upstream }} true
           done
 
       - name: Build swoole extension
         run: |
           set -e
           for VERSION in ${{ join(matrix.series.swoole, ' ') }}; do
-            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} ${{ matrix.series.version }} swoole "$VERSION" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
+            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} swoole "$VERSION" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
           done
 
       - name: Build openswoole extension
         run: |
           set -e
           for VERSION in ${{ join(matrix.series.openswoole, ' ') }}; do
-            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} ${{ matrix.series.version }} openswoole "$VERSION" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
+            ./scripts/build-extension.sh ${{ matrix.stack.name }} ${{ matrix.series.php }} openswoole "$VERSION" "php-${{ env.PHP_VERSION }}" ${{ matrix.stack.upstream }} true
           done

--- a/.github/workflows/mkrepo.yml
+++ b/.github/workflows/mkrepo.yml
@@ -31,10 +31,6 @@ jobs:
     strategy:
       matrix:
         stack:
-          - name: "heroku-22"
-            stable: "dist-heroku-22-stable/"
-            develop: "dist-heroku-22-develop/"
-            os: "ubuntu-latest"
           - name: "heroku-24"
             stable: "dist-heroku-24-amd64-stable/"
             develop: "dist-heroku-24-amd64-develop/"
@@ -43,11 +39,22 @@ jobs:
             stable: "dist-heroku-24-arm64-stable/"
             develop: "dist-heroku-24-arm64-develop/"
             os: "ubuntu-24.04-arm"
+          - name: "heroku-26"
+            stable: "dist-heroku-26-amd64-stable/"
+            develop: "dist-heroku-26-amd64-develop/"
+            os: "ubuntu-latest"
+          - name: "heroku-26"
+            stable: "dist-heroku-26-arm64-stable/"
+            develop: "dist-heroku-26-arm64-develop/"
+            os: "ubuntu-24.04-arm"
 
     env:
       S3_BUCKET: ${{ secrets.S3_BUCKET || 'heroku-php-extensions' }}
       S3_PREFIX: ${{ inputs.S3_PREFIX || matrix.stack.develop }}
+      S3_REGION: ${{ secrets.S3_REGION || 'us-east-1' }}
       BUILDPACK: ./vendor/heroku/heroku-buildpack-php
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout
@@ -71,5 +78,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           docker run --rm \
-            --env-file=${BUILDPACK}/support/build/_docker/env.default \
+            --env-file=${BUILDPACK}/support/build/docker/env.default \
             ${{ matrix.stack.name }} mkrepo.sh --upload

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,11 +20,6 @@ jobs:
     strategy:
       matrix:
         stack:
-          - name: "heroku-22"
-            arch: "amd64"
-            stable: "dist-heroku-22-stable/"
-            develop: "dist-heroku-22-develop/"
-            os: "ubuntu-latest"
           - name: "heroku-24"
             arch: "amd64"
             stable: "dist-heroku-24-amd64-stable/"
@@ -35,10 +30,23 @@ jobs:
             stable: "dist-heroku-24-arm64-stable/"
             develop: "dist-heroku-24-arm64-develop/"
             os: "ubuntu-24.04-arm"
+          - name: "heroku-26"
+            arch: "amd64"
+            stable: "dist-heroku-26-amd64-stable/"
+            develop: "dist-heroku-26-amd64-develop/"
+            os: "ubuntu-latest"
+          - name: "heroku-26"
+            arch: "arm64"
+            stable: "dist-heroku-26-arm64-stable/"
+            develop: "dist-heroku-26-arm64-develop/"
+            os: "ubuntu-24.04-arm"
 
     env:
       S3_BUCKET: ${{ secrets.S3_BUCKET || 'heroku-php-extensions' }}
       BUILDPACK: ./vendor/heroku/heroku-buildpack-php
+      S3_REGION: ${{ secrets.S3_REGION || 'us-east-1' }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout
@@ -63,5 +71,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "yes" | docker run --rm -i \
-            --env-file=${BUILDPACK}/support/build/_docker/env.default \
+            --env-file=${BUILDPACK}/support/build/docker/env.default \
             ${{ matrix.stack.name }} sync.sh $S3_BUCKET ${{ matrix.stack.stable }} $S3_BUCKET ${{ matrix.stack.develop }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-06-11
+- Added `heroku-26` stack support
+- Added Swoole v6.2.1
+
+### Changed
+- Adapted build workflow according to latest changes done in [heroku/heroku-buildpack-php](https://github.com/heroku/heroku-buildpack-php/pull/907)
+
+### Removed
+- Dropped `heroku-22` stack support
+
 ## [3.0.0] - 2026-03-05
 
 ### Added
@@ -112,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 [Unreleased]: https://github.com/cachewerk/heroku-php-extensions/compare/v3.0.0...HEAD
+[3.1.0]: https://github.com/cachewerk/heroku-php-extensions/compare/v3.0.1...v3.1.0
 [3.0.0]: https://github.com/cachewerk/heroku-php-extensions/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/cachewerk/heroku-php-extensions/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/cachewerk/heroku-php-extensions/compare/v1.2.6...v2.0.0

--- a/README.md
+++ b/README.md
@@ -95,22 +95,22 @@ Create a custom Dockerfile for `heroku-24`.
 ./scripts/build-lib.sh heroku-24 zstd 1.4.9
 
 # Build igbinary
-./scripts/build-extension.sh heroku-24 8.4 20240924 igbinary 3.2.16 "php-8.4.*" "dist-heroku-24-amd64-stable/"
+./scripts/build-extension.sh heroku-24 8.4 igbinary 3.2.16 "php-8.4.*" "dist-heroku-24-amd64-stable/"
 
 # Build msgpack
-./scripts/build-extension.sh heroku-24 8.4 20240924 msgpack 2.2.0 "php-8.4.*" "dist-heroku-24-amd64-stable/"
+./scripts/build-extension.sh heroku-24 8.4 msgpack 2.2.0 "php-8.4.*" "dist-heroku-24-amd64-stable/"
 
 # Build phpredis (has extra dependencies, libraries need to be "deployed" already)
-./scripts/build-extension.sh heroku-24 8.4 20240924 redis 6.3.0 "php-8.4.*,libraries/liblzf-*,libraries/lz4-*,libraries/zstd-*,extensions/no-debug-non-zts-20240924/igbinary-*,extensions/no-debug-non-zts-20240924/msgpack-*" "dist-heroku-24-amd64-stable/"
+./scripts/build-extension.sh heroku-24 8.4 redis 6.3.0 "php-8.4.*,liblzf-*,lz4-*,zstd-*,ext-igbinary-*_php-8.4,ext-msgpack-*_php-8.4" "dist-heroku-24-amd64-stable/"
 
 # Build relay (has extra dependencies, libraries need to be "deployed" already)
-./scripts/build-extension.sh heroku-24 8.4 20240924 relay 0.20.0 "php-8.4.*,libraries/liblzf-*,libraries/lz4-*,libraries/zstd-*,extensions/no-debug-non-zts-20240924/igbinary-*,extensions/no-debug-non-zts-20240924/msgpack-*" "dist-heroku-24-amd64-stable/"
+./scripts/build-extension.sh heroku-24 8.4 relay 0.20.0 "php-8.4.*,liblzf-*,lz4-*,zstd-*,ext-igbinary-*_php-8.4,ext-msgpack-*_php-8.4" "dist-heroku-24-amd64-stable/"
 
 # Build swoole
-./scripts/build-extension.sh heroku-24 8.4 20240924 swoole 6.1.7 "php-8.4.*" "dist-heroku-24-amd64-stable/"
+./scripts/build-extension.sh heroku-24 8.4 swoole 6.1.7 "php-8.4.*" "dist-heroku-24-amd64-stable/"
 
 # Build openswoole
-./scripts/build-extension.sh heroku-24 8.4 20240924 openswoole 25.2.0 "php-8.4.*" "dist-heroku-24-amd64-stable/"
+./scripts/build-extension.sh heroku-24 8.4 openswoole 25.2.0 "php-8.4.*" "dist-heroku-24-amd64-stable/"
 ```
 ### Versions
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-igbinary": "*",
         "ext-msgpack": "*",
         "ext-redis": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c367bb8077b561eb9a2ebdeb5ed8041f",
+    "content-hash": "ed8b228baae5e682a3980962af7df75e",
     "packages": [],
     "packages-dev": [
         {
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/heroku/heroku-buildpack-php.git",
-                "reference": "74456d03da581b9a0568157afdd9543688262bf8"
+                "reference": "fdf6d003550a1e537a0f51c2d9f8fc940ce76dc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/74456d03da581b9a0568157afdd9543688262bf8",
-                "reference": "74456d03da581b9a0568157afdd9543688262bf8",
+                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/fdf6d003550a1e537a0f51c2d9f8fc940ce76dc1",
+                "reference": "fdf6d003550a1e537a0f51c2d9f8fc940ce76dc1",
                 "shasum": ""
             },
             "default-branch": true,
@@ -51,7 +51,7 @@
                 "issues": "https://github.com/heroku/heroku-buildpack-php/issues",
                 "source": "https://github.com/heroku/heroku-buildpack-php/tree/main"
             },
-            "time": "2026-02-18T15:58:28+00:00"
+            "time": "2026-05-26T17:17:18+00:00"
         }
     ],
     "aliases": [],
@@ -62,13 +62,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-igbinary": "*",
         "ext-msgpack": "*",
         "ext-redis": "*",
         "ext-relay": "*",
         "ext-swoole": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/extensions/igbinary
+++ b/extensions/igbinary
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-dep_name=$(basename $BASH_SOURCE)
+dep_name=ext-igbinary
 
-source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/extensions/pecl
+source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/formulae/include/pecl-ext

--- a/extensions/msgpack
+++ b/extensions/msgpack
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-dep_name=$(basename $BASH_SOURCE)
+dep_name=ext-msgpack
 
-source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/extensions/pecl
+source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/formulae/include/pecl-ext

--- a/extensions/openswoole
+++ b/extensions/openswoole
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-dep_name=$(basename $BASH_SOURCE)
+dep_name=ext-openswoole
 
 CONFIGURE_EXTRA="--enable-swoole-json --enable-swoole-curl --enable-http2 --enable-sockets --enable-mysqlnd --enable-openssl --with-postgres"
 
-source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/extensions/pecl
+source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/formulae/include/pecl-ext

--- a/extensions/redis
+++ b/extensions/redis
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-dep_name=$(basename $BASH_SOURCE)
+dep_name=ext-redis
 
 series=$(/app/.heroku/php/bin/php-config --version | cut -d. -f1,2)
 
@@ -10,4 +10,4 @@ CONFIGURE_EXTRA="--enable-redis-igbinary --enable-redis-msgpack --enable-redis-l
 
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\",\"heroku-sys/liblzf\":\"*\",\"heroku-sys/lz4\":\"*\",\"heroku-sys/zstd\":\"*\",\"heroku-sys/ext-json\":\"*\",\"heroku-sys/ext-igbinary\":\"*\",\"heroku-sys/ext-msgpack\":\"*\"}"}"
 
-source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/extensions/pecl
+source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/formulae/include/pecl-ext

--- a/extensions/relay
+++ b/extensions/relay
@@ -3,7 +3,7 @@
 set -o pipefail
 set -eu
 
-source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/_util/include/manifest.sh
+source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/util/include/manifest.sh
 
 OUT_PREFIX=$1
 
@@ -12,17 +12,19 @@ export PATH=${OUT_PREFIX}/bin:${PATH}
 series=$(php-config --version | cut -d. -f1,2)
 php_ext_dir=$(php-config --extension-dir)
 
-dep_name=relay
-dep_formula=${0#$WORKSPACE_DIR/}
-dep_version=${dep_formula##*"/${dep_name}-"}
-dep_package=ext-${dep_name}-${dep_version}
+dep_name=ext-relay
+dep_package=${0#"${WORKSPACE_DIR}/"} # trim WORKSPACE_DIR prefix from $0 (the invoked package recipe)
+dep_formula=${dep_package} # trim "_php-x.y" suffix from package name to get formula name
+dep_build=${dep_package#"${dep_name}-"} # strip formula name from front of full package name
+dep_build=${dep_build%"_php-${series}"} # strip "_php-x.y" suffix from end
+dep_version=${dep_build%%"+"*} # strip build metadata off the end of the version
 dep_variant=$(if openssl version | grep -q "OpenSSL 3"; then echo "+libssl3"; else echo ""; fi)
 dep_dirname=relay-v${dep_version}-php${series}-debian-x86-64${dep_variant}
 dep_archive_name=${dep_dirname}.tar.gz
 dep_url=https://builds.r2.relay.so/v${dep_version}/${dep_archive_name}
 dep_manifest=${dep_package}_php-${series}.composer.json
 
-echo "-----> Building ${dep_package}..."
+echo "-----> Building ${dep_name} (${dep_version}, for PHP ${series}) ..."
 
 curl -L ${dep_url} | tar xz
 
@@ -48,6 +50,6 @@ MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/relay.ini-dist\"}"}"
 
-python $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/extensions/swoole
+++ b/extensions/swoole
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-dep_name=$(basename $BASH_SOURCE)
+dep_name=ext-swoole
 
 CONFIGURE_EXTRA="--enable-swoole-json --enable-swoole-curl --enable-http2 --enable-sockets --enable-mysqlnd --enable-openssl"
 
-source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/extensions/pecl
+source $(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/formulae/include/pecl-ext

--- a/libraries/liblzf
+++ b/libraries/liblzf
@@ -6,21 +6,21 @@ set -o pipefail
 # fail harder
 set -eu
 
-util_dir=$(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/_util
+util_dir=$(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/util
 
 source ${util_dir}/include/manifest.sh
 
 OUT_PREFIX=$1
 
-dep_formula=${0#$WORKSPACE_DIR/}
+dep_formula=${0##*/}
 dep_name=$(basename $BASH_SOURCE)
-dep_version=${dep_formula##*"/${dep_name}-"}
+dep_version=${dep_formula##*-}
 dep_package=${dep_name}-${dep_version}
 dep_dirname=liblzf-${dep_version}
 dep_url=https://deb.debian.org/debian/pool/main/libl/liblzf/liblzf_${dep_version}.orig.tar.gz
 dep_manifest=${dep_package}.composer.json
 
-echo "-----> Building ${dep_package}..."
+echo "-----> Building formula ${dep_formula} which results in package ${dep_package}..."
 
 curl -L ${dep_url} | tar xz
 pushd ${dep_dirname}

--- a/libraries/lz4
+++ b/libraries/lz4
@@ -6,20 +6,20 @@ set -o pipefail
 # fail harder
 set -eu
 
-util_dir=$(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/_util
+util_dir=$(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/util
 
 source ${util_dir}/include/manifest.sh
 
 OUT_PREFIX=$1
 
-dep_formula=${0#$WORKSPACE_DIR/}
+dep_formula=${0##*/}
 dep_name=$(basename $BASH_SOURCE)
-dep_version=${dep_formula##*"/${dep_name}-"}
+dep_version=${dep_formula##*-}
 dep_package=${dep_name}-${dep_version}
 dep_url=https://github.com/lz4/lz4/archive/v${dep_version}.tar.gz
 dep_manifest=${dep_package}.composer.json
 
-echo "-----> Building ${dep_package}..."
+echo "-----> Building formula ${dep_formula} which results in package ${dep_package}..."
 
 curl -L ${dep_url} | tar xz
 pushd ${dep_package}

--- a/libraries/zstd
+++ b/libraries/zstd
@@ -6,20 +6,20 @@ set -o pipefail
 # fail harder
 set -eu
 
-util_dir=$(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/_util
+util_dir=$(dirname $BASH_SOURCE)/../vendor/heroku/heroku-buildpack-php/support/build/util
 
 source ${util_dir}/include/manifest.sh
 
 OUT_PREFIX=$1
 
-dep_formula=${0#$WORKSPACE_DIR/}
+dep_formula=${0##*/}
 dep_name=$(basename $BASH_SOURCE)
-dep_version=${dep_formula##*"/${dep_name}-"}
+dep_version=${dep_formula##*-}
 dep_package=${dep_name}-${dep_version}
 dep_url=https://github.com/facebook/zstd/releases/download/v${dep_version}/zstd-${dep_version}.tar.gz
 dep_manifest=${dep_package}.composer.json
 
-echo "-----> Building ${dep_package}..."
+echo "-----> Building formula ${dep_formula} which results in package ${dep_package}..."
 
 curl -L ${dep_url} | tar xz
 pushd ${dep_package}

--- a/scripts/build-extension.sh
+++ b/scripts/build-extension.sh
@@ -6,12 +6,11 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 HEROKUSTACK="$1" # e.g. "heroku-22"
 PHP_VERSION="$2" # e.g. "8.4"
-PHP_APIVERSION="$3" # e.g. "20240924"
-EXTENSION_NAME="$4" # e.g. "igbinary"
-EXTENSION_VERSION="$5" # e.g. "3.2.15"
-EXTENSION_DEPS="$6" # e.g. "php-$PHP_VERSION.*"
-UPSTREAM_S3_PREFIX="$7" # upstream (lang-php) S3 prefix, e.g. "dist-heroku-24-amd64-stable/"
-WITH_DEPLOY=${8:-"false"} # e.g. "true" or "false"
+EXTENSION_NAME="$3" # e.g. "igbinary"
+EXTENSION_VERSION="$4" # e.g. "3.2.15"
+EXTENSION_DEPS="$5" # e.g. "php-$PHP_VERSION.*"
+UPSTREAM_S3_PREFIX="$6" # upstream (lang-php) S3 prefix, e.g. "dist-heroku-24-amd64-stable/"
+WITH_DEPLOY=${7:-"false"} # e.g. "true" or "false"
 
 if [ "$EXTENSION_VERSION" == "" ]; then
     echo "No version was provided for $EXTENSION_NAME, skipping build."
@@ -20,24 +19,28 @@ fi
 
 echo "--- Building $EXTENSION_NAME $EXTENSION_VERSION ---"
 
-EXTENSION_FOLDER="$SCRIPT_DIR/../extensions/no-debug-non-zts-${PHP_APIVERSION}/"
-EXTENSION_FILE="$EXTENSION_FOLDER${EXTENSION_NAME}-${EXTENSION_VERSION}"
+EXTENSION_FOLDER="$SCRIPT_DIR/.."
+EXTENSION_FILE="$EXTENSION_FOLDER/ext-${EXTENSION_NAME}-${EXTENSION_VERSION}_php-${PHP_VERSION}"
+
 # Create the extension build script
-mkdir -p $EXTENSION_FOLDER
 cat <<EOF > "$EXTENSION_FILE"
 #!/bin/bash
 # Build Path: /app/.heroku/php/
 # Build Deps: $EXTENSION_DEPS
-source \$(dirname \$0)/../$EXTENSION_NAME
+WORKSPACE_DIR=/workspace
+source \$(dirname \$0)/extensions/$EXTENSION_NAME
 EOF
 
 # Set the build command based on whether we want to deploy or not
 COMMAND="bob build"
 OVERWRITE_FLAG=""
-ENV_FILE=".env"
+if [[ -f ".env" ]]; then
+    ENV_FILE=".env"
+else
+    ENV_FILE="$SCRIPT_DIR/../vendor/heroku/heroku-buildpack-php/support/build/docker/env.default"
+fi
 if [ "$WITH_DEPLOY" = "true" ]; then
     COMMAND="deploy.sh"
-    ENV_FILE="$SCRIPT_DIR/../vendor/heroku/heroku-buildpack-php/support/build/_docker/env.default"
     OVERWRITE_FLAG="--overwrite"
 fi
 
@@ -46,10 +49,10 @@ set -x
 docker run --rm \
 -v ${SCRIPT_DIR}/../:/workspace \
 -w /workspace \
---env UPSTREAM_S3_BUCKET=lang-php \
+--env UPSTREAM_S3_BUCKET=heroku-buildpack-php \
 --env UPSTREAM_S3_PREFIX=${UPSTREAM_S3_PREFIX} \
 --env-file="$ENV_FILE" \
 ${HEROKUSTACK} ${COMMAND} \
-${OVERWRITE_FLAG} extensions/no-debug-non-zts-${PHP_APIVERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}
+${OVERWRITE_FLAG} ext-${EXTENSION_NAME}-${EXTENSION_VERSION}_php-${PHP_VERSION}
 
 set +x

--- a/scripts/build-lib.sh
+++ b/scripts/build-lib.sh
@@ -17,19 +17,24 @@ fi
 echo "--- Building $LIBNAME $LIBVERSION ---"
 
 # Create the library build script
-cat <<EOF > "${SCRIPT_DIR}/../libraries/${LIBNAME}-${LIBVERSION}"
+cat <<EOF > "${SCRIPT_DIR}/../${LIBNAME}-${LIBVERSION}"
 #!/bin/bash
 # Build Path: /app/.heroku/php/
-source \$(dirname \$0)/$LIBNAME
+WORKSPACE_DIR=/workspace/libraries
+source \$(dirname \$0)/libraries/$LIBNAME
 EOF
 
 # Set the build command based on whether we want to deploy or not
 COMMAND="bob build"
-ENV_FILE=".env"
+
+if [[ -f ".env" ]]; then
+    ENV_FILE=".env"
+else
+    ENV_FILE="$SCRIPT_DIR/../vendor/heroku/heroku-buildpack-php/support/build/docker/env.default"
+fi
 OVERWRITE_FLAG=""
 if [ "$WITH_DEPLOY" = "true" ]; then
     COMMAND="deploy.sh"
-    ENV_FILE="$SCRIPT_DIR/../vendor/heroku/heroku-buildpack-php/support/build/_docker/env.default"
     OVERWRITE_FLAG="--overwrite"
 fi
 
@@ -40,6 +45,6 @@ docker run --rm \
 -w /workspace \
 --env-file="$ENV_FILE" \
 $HEROKUSTACK \
-${COMMAND} ${OVERWRITE_FLAG} libraries/${LIBNAME}-${LIBVERSION}
+${COMMAND} ${OVERWRITE_FLAG} ${LIBNAME}-${LIBVERSION}
 
 set +x

--- a/scripts/create-dockerfile.sh
+++ b/scripts/create-dockerfile.sh
@@ -4,9 +4,9 @@ HEROKUSTACK="$1"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 mkdir -p ${SCRIPT_DIR}/../docker/build/
-cat ${SCRIPT_DIR}/../vendor/heroku/heroku-buildpack-php/support/build/_docker/${HEROKUSTACK}.Dockerfile > ${SCRIPT_DIR}/../docker/build/${HEROKUSTACK}.Dockerfile
+cat ${SCRIPT_DIR}/../vendor/heroku/heroku-buildpack-php/support/build/docker/${HEROKUSTACK}.Dockerfile > ${SCRIPT_DIR}/../docker/build/${HEROKUSTACK}.Dockerfile
 
 cat <<EOF >> "${SCRIPT_DIR}/../docker/build/${HEROKUSTACK}.Dockerfile"
 ENV WORKSPACE_DIR=/workspace
-ENV PATH=/app/vendor/heroku/heroku-buildpack-php/support/build/_util:\$PATH
+ENV PATH=/app/vendor/heroku/heroku-buildpack-php/support/build/util:\$PATH
 EOF


### PR DESCRIPTION
This PR adds the Heroku-26 stack and removes the Heroku-22 stack. This was quite a "Zangengeburt" for me as not only the scripts have slightly moved inside of `heroku/heroku-buildpack-php` but they also depend on the new flat repository structure which has been merged here: https://github.com/heroku/heroku-buildpack-php/pull/907

Add Heroku-26
Like the Heroku-24 stack the Heroku-26 supports two architectures: amd64 and arm64

Remove Heroku-22 stack
The deprecated Heroku-22 stack does no work anymore with the new S3 upstream (lang-php => heroku-buildpack-php) and since it's been deprecated anyway, I have simply removed it.

... and all of this just because I wanted the final Swoole 6.2.x on Heroku :sweat_smile: 

Note: I can't say how the new flat structure (extensions and libraries no longer in sub folders on S3) will behave when mixed with the old one. I don't think there will be an issue but I just wanted to have mentioned it